### PR TITLE
Do not use saved window location if it is offscreen.

### DIFF
--- a/script/gui.lua
+++ b/script/gui.lua
@@ -62,6 +62,12 @@ function syncDataToUI(player_index)
     end
 end
 
+local function is_position_off_screen(position, resolution)
+    return position.x < 0 or position.y < 0 or
+           position.x > (resolution.width - 20) or
+           position.y > (resolution.height - 20)
+end
+
 function ensureWindow(player_index)
     local player = game.get_player(player_index)
 
@@ -86,7 +92,7 @@ function ensureWindow(player_index)
     global.ui_state[player_index].dialog = dialog    
     
     local ui_state = global.ui_state[player_index]
-    if ui_state.location then
+    if ui_state.location and is_position_off_screen(ui_state.location, player.display_resolution) == false then
         dialog.main_window.location = global.ui_state[player_index].location
     else
         dialog.main_window.location = { 0, player.display_resolution.height - toolbarHeight(player.display_scale) }


### PR DESCRIPTION
Problem statement: I ran into a problem when I copied a save from my desktop to my laptop where the desktop resolution was higher and it saved the window location offscreen.

Solution: Check to see if the window location is offscreen when the window is being opened. If it is offscreen, then just use the default location instead.